### PR TITLE
Edited script to detect if it is being run at an Origen application. …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source 'http://rubygems.org'
 
 # Only development dependencies (things your only plugin needs when running in its own workspace) should
 # be listed here in the Gemfile

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       origen
 
 GEM
-  remote: https://rubygems.org/
+  remote: http://rubygems.org/
   specs:
     activesupport (4.2.8)
       i18n (~> 0.7)

--- a/bin/fix_my_workspace
+++ b/bin/fix_my_workspace
@@ -4,7 +4,15 @@ $VERBOSE = nil  # Don't care about world writable dir warnings and the like
 if $_fix_my_workspace_version_check
   $_fix_my_workspace_version = '0.6.0'
 else
-  require 'origen'
+  if File.exists?(File.expand_path('../../lib/origen.rb', __FILE__))
+    # If this script is being run from within an origen application, use that Origen application,
+    # not the system installed origen version.
+    $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
+    require 'origen'
+  else
+    # Use system-installed Origen (the gem in system Ruby)
+    require 'origen'
+  end
 
   if !Origen.site_config.gem_manage_bundler
     puts 'Sorry but you have opted to manage Bundler yourself via your Origen site config, and this means'

--- a/bin/fix_my_workspace
+++ b/bin/fix_my_workspace
@@ -5,8 +5,8 @@ if $_fix_my_workspace_version_check
   $_fix_my_workspace_version = '0.6.0'
 else
   if File.exists?(File.expand_path('../../lib/origen.rb', __FILE__))
-    # If this script is being run from within an origen application, use that Origen application,
-    # not the system installed origen version.
+    # If this script is being run from within an origen-core workspace, use that Origen-core,
+    # not the system-installed origen-core version.
     $LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
     require 'origen'
   else


### PR DESCRIPTION
Edited script to detect if it is being run at an Origen application. If it is, adds that path to Ruby's load path so that the version of Origen it's inside will be used, not the system versio
n.

Ex. script is inside Origen 0.20.2 workspace, but the Origen version inside of the system's gems is 0.11.0

~~~
fix_my_workspace 0.6.0, fix_my_workspace is located anywhere:
  require 'origen' #=> Origen 0.11.0

fix_my_workspace_with_my_origen, fix_my_workspace invoked inside Origen:
  require 'origen' #=> 0.20.2

fix_my_workspace_with_my_origen, fix_my_workspace moved out somewhere else:
(not inside Origen anymore, or inside the origen_updater app for example)
  require 'origen' #=> 0.11.0
~~~
